### PR TITLE
Clarify pythonLocation behavior for PyPy and GraalPy in environment variables table

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -472,12 +472,16 @@ jobs:
 
 These environment variables become available after setup-python action execution:
 
-| **Env.variable**      | **Description** |
-| ----------- | ----------- |
-| pythonLocation      |Contains the absolute path to the folder where the requested version of Python or PyPy is installed|
-| Python_ROOT_DIR   | https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython        |
-| Python2_ROOT_DIR   |https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2|
-| Python3_ROOT_DIR   |https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3|
+### Environment variables
+
+These environment variables become available after setup-python action execution:
+
+| Env. variable        | Description |
+|----------------------|-------------|
+| `pythonLocation`     | Contains the absolute path to the folder where the requested version of Python, PyPy, or GraalPy is installed. <br><br>**Executable location by implementation:** <br>• **CPython** – `$pythonLocation/python` (Linux/macOS), `$pythonLocation/python.exe` (Windows) <br>• **PyPy** – `$pythonLocation/bin/python` (Linux/macOS), `$pythonLocation/python.exe` (Windows) <br>• **GraalPy** – `$pythonLocation/bin/python` (Linux/macOS), `$pythonLocation/python.exe` (Windows) <br><br>Note: CPython versions include a symlink or copy of the `python` executable at the root, while PyPy and GraalPy retain upstream directory layouts. |
+| `Python_ROOT_DIR`    | https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython |
+| `Python2_ROOT_DIR`   | https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2 |
+| `Python3_ROOT_DIR`   | https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3 |
 
 ## Using `update-environment` flag
 


### PR DESCRIPTION
**Description:**
This PR enhances the documentation for the `pythonLocation` environment variable in `advanced-usage.md` by clarifying how the path to the `python` executable differs across implementations (CPython, PyPy, GraalPy) and platforms (Linux/macOS, Windows).

**Check list:**
- [ X] Mark if documentation changes are required.
